### PR TITLE
Refactor to native Node.js test runner

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -87930,12 +87930,12 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(76760);
 /* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(node_path__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var isomorphic_dompurify__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(65061);
-/* harmony import */ var _lib_createIssueBody__WEBPACK_IMPORTED_MODULE_8__ = __nccwpck_require__(46697);
-/* harmony import */ var _lib_extractInput__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(21183);
-/* harmony import */ var _lib_generateMeetingTimes__WEBPACK_IMPORTED_MODULE_7__ = __nccwpck_require__(45458);
-/* harmony import */ var _lib_getLabeledIssuesAndPRs__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(23279);
-/* harmony import */ var _lib_output__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(89345);
-/* harmony import */ var _lib_parseICS__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(54744);
+/* harmony import */ var _lib_createIssueBody_js__WEBPACK_IMPORTED_MODULE_8__ = __nccwpck_require__(46697);
+/* harmony import */ var _lib_extractInput_js__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(21183);
+/* harmony import */ var _lib_generateMeetingTimes_js__WEBPACK_IMPORTED_MODULE_7__ = __nccwpck_require__(45458);
+/* harmony import */ var _lib_getLabeledIssuesAndPRs_js__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(23279);
+/* harmony import */ var _lib_output_js__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(89345);
+/* harmony import */ var _lib_parseICS_js__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(54744);
 
 
 
@@ -87945,7 +87945,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 
 
 
-const { dryRun, meetingPath, org, repo, slackChannel, timezones, agendaLabel, orgWide, } = (0,_lib_extractInput__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .A)();
+const { dryRun, meetingPath, org, repo, slackChannel, timezones, agendaLabel, orgWide, } = (0,_lib_extractInput_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .A)();
 const isDryRun = dryRun || false;
 let icsContents;
 try {
@@ -87955,12 +87955,12 @@ catch (err) {
     console.error('Error reading .ics', err.message);
     throw err;
 }
-const { location, nextMeetingDateAndTimeUTC } = await (0,_lib_parseICS__WEBPACK_IMPORTED_MODULE_6__/* ["default"] */ .A)(icsContents);
-const nextMeetingDateAndTimesAcrossTimeZones = (0,_lib_generateMeetingTimes__WEBPACK_IMPORTED_MODULE_7__/* ["default"] */ .A)(timezones, nextMeetingDateAndTimeUTC);
-const issues = await (0,_lib_getLabeledIssuesAndPRs__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .A)(org, repo, agendaLabel, orgWide);
-const bodyContent = (0,_lib_createIssueBody__WEBPACK_IMPORTED_MODULE_8__/* ["default"] */ .A)(repo, slackChannel, nextMeetingDateAndTimesAcrossTimeZones, issues, location, agendaLabel);
+const { location, nextMeetingDateAndTimeUTC } = await (0,_lib_parseICS_js__WEBPACK_IMPORTED_MODULE_6__/* ["default"] */ .A)(icsContents);
+const nextMeetingDateAndTimesAcrossTimeZones = (0,_lib_generateMeetingTimes_js__WEBPACK_IMPORTED_MODULE_7__/* ["default"] */ .A)(timezones, nextMeetingDateAndTimeUTC);
+const issues = await (0,_lib_getLabeledIssuesAndPRs_js__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .A)(org, repo, agendaLabel, orgWide);
+const bodyContent = (0,_lib_createIssueBody_js__WEBPACK_IMPORTED_MODULE_8__/* ["default"] */ .A)(repo, slackChannel, nextMeetingDateAndTimesAcrossTimeZones, issues, location, agendaLabel);
 const sanitizedBodyContent = isomorphic_dompurify__WEBPACK_IMPORTED_MODULE_2__/* ["default"].sanitize */ .Ay.sanitize(bodyContent);
-(0,_lib_output__WEBPACK_IMPORTED_MODULE_5__/* ["default"] */ .A)(org, repo, isDryRun, sanitizedBodyContent, nextMeetingDateAndTimeUTC, location);
+(0,_lib_output_js__WEBPACK_IMPORTED_MODULE_5__/* ["default"] */ .A)(org, repo, isDryRun, sanitizedBodyContent, nextMeetingDateAndTimeUTC, location);
 
 __webpack_async_result__();
 } catch(e) { __webpack_async_result__(e); } }, 1);
@@ -88130,10 +88130,10 @@ const getLabeledIssuesAndPRs = async (org, repo, agendaLabel = 'agenda', orgWide
 /* harmony export */   A: () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(57358);
-/* harmony import */ var _extractInput__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(21183);
+/* harmony import */ var _extractInput_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(21183);
 
 
-const input = (0,_extractInput__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .A)();
+const input = (0,_extractInput_js__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .A)();
 const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_0__/* .getOctokit */ .Q)(input.token);
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (octokit);
 
@@ -88147,7 +88147,7 @@ const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_0__/* .getOctokit */
 /* harmony export */   A: () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(82075);
-/* harmony import */ var _getOctokit__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(32593);
+/* harmony import */ var _getOctokit_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(32593);
 
 
 const output = async (org, repo, isDryRun, bodyContent, date, location) => {
@@ -88157,7 +88157,7 @@ const output = async (org, repo, isDryRun, bodyContent, date, location) => {
     }
     else {
         try {
-            const { data: newIssue } = await _getOctokit__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .A.rest.issues.create({
+            const { data: newIssue } = await _getOctokit_js__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .A.rest.issues.create({
                 owner: org,
                 repo: repo,
                 title: `Agenda for ${date.toLocaleString()}`,

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
 		"dev": "pnpm package --watch",
 		"package": "npx ncc build src/index.ts -o dist --license licenses.txt",
 		"lint": "pnpm biome check src",
-		"test": "vitest",
-		"coverage": "vitest run --coverage"
+		"test": "node --test --experimental-test-module-mocks \"src/**/*.test.ts\"",
+		"test:watch": "node --test --watch --experimental-test-module-mocks \"src/**/*.test.ts\"",
+		"coverage": "node --test --experimental-test-module-mocks --experimental-test-coverage \"src/**/*.test.ts\""
 	},
 	"keywords": [
 		"actions",
@@ -35,10 +36,8 @@
 		"@types/luxon": "3.7.1",
 		"@types/node": "24.12.4",
 		"@vercel/ncc": "0.38.4",
-		"@vitest/coverage-v8": "4.1.6",
 		"rrule": "2.8.1",
-		"typescript": "6.0.3",
-		"vitest": "4.1.6"
+		"typescript": "6.0.3"
 	},
 	"author": "bmuenzenmeyer",
 	"license": "Apache-2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,18 +36,12 @@ importers:
       '@vercel/ncc':
         specifier: 0.38.4
         version: 0.38.4
-      '@vitest/coverage-v8':
-        specifier: 4.1.6
-        version: 4.1.6(vitest@4.1.6)
       rrule:
         specifier: 2.8.1
         version: 2.8.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      vitest:
-        specifier: 4.1.6
-        version: 4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@7.1.5(@types/node@24.12.4))
 
 packages:
 
@@ -83,27 +77,6 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
-
-  '@bcoe/v8-coverage@1.0.2':
-    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
-    engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.15':
     resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
@@ -198,162 +171,6 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -362,19 +179,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
@@ -422,143 +226,6 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@rollup/rollup-android-arm-eabi@4.60.3':
-    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.3':
-    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.60.3':
-    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.3':
-    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.60.3':
-    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.3':
-    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
-    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
-    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.3':
-    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.3':
-    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-gnu@4.60.3':
-    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.3':
-    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
-    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.3':
-    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
-    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.3':
-    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.3':
-    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.3':
-    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.60.3':
-    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-openbsd-x64@4.60.3':
-    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.3':
-    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.3':
-    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.3':
-    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.60.3':
-    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.3':
-    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@types/chai@5.2.2':
-    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
-
-  '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/luxon@3.7.1':
     resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
@@ -572,63 +239,15 @@ packages:
     resolution: {integrity: sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==}
     hasBin: true
 
-  '@vitest/coverage-v8@4.1.6':
-    resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
-    peerDependencies:
-      '@vitest/browser': 4.1.6
-      vitest: 4.1.6
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
-
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
-
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
-
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
-
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
-
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
-
-  ast-v8-to-istanbul@1.0.0:
-    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
-
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  chai@6.2.2:
-    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
-    engines: {node: '>=18'}
-
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -648,48 +267,12 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
-
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
-    engines: {node: '>=12.0.0'}
-
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
-
-  fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
-  fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  html-escaper@2.0.2:
-    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -697,21 +280,6 @@ packages:
   isomorphic-dompurify@3.13.0:
     resolution: {integrity: sha512-QzgzjAGJN0QoOpLWx7mkMhhTQvQXsBpS6oEi2Wy58mEWwrvaRJrx5hrVEdsM70nNKOwHCHj3bwYkwI+HFd3Khg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
-
-  istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-report@3.0.1:
-    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-reports@3.2.0:
-    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
-    engines: {node: '>=8'}
-
-  js-tokens@10.0.0:
-    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   jsbi@4.3.2:
     resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
@@ -736,51 +304,15 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
-  magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  magicast@0.5.3:
-    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
-
-  make-dir@4.0.0:
-    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
-
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   node-ical@0.26.1:
     resolution: {integrity: sha512-KoYLpsz7Ga9lPDpt9vy0iKcgcb/9Ix7ICRZd0csLXMl2lZOSONGj7HrcktJFR7Jid1l44Zu1H4k/1nB04rWPgQ==}
     engines: {node: '>=20'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
-
-  pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -789,11 +321,6 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-
-  rollup@4.60.3:
-    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
 
   rrule-temporal@1.5.3:
     resolution: {integrity: sha512-qALnXyu4MKNUeykkkO0r6Xxl5or3rM8Cf6ibKIe/29sgmq3tGm1oNq4G1Ddp8Ku3mnKmvC3+3yFAJ3OgOu6OJw==}
@@ -805,27 +332,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -835,25 +344,6 @@ packages:
 
   temporal-spec@0.3.1:
     resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
-
-  tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.30:
     resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
@@ -896,87 +386,6 @@ packages:
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
-  vite@7.1.5:
-    resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -992,11 +401,6 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
-    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -1057,21 +461,6 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
-
-  '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/parser@7.29.3':
-    dependencies:
-      '@babel/types': 7.29.0
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
-  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.15':
     optionalDependencies:
@@ -1136,96 +525,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
-    optional: true
-
   '@exodus/bytes@1.15.0': {}
-
-  '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@js-temporal/polyfill@0.5.1':
     dependencies:
@@ -1284,91 +584,6 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@rollup/rollup-android-arm-eabi@4.60.3':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.60.3':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.3':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.3':
-    optional: true
-
-  '@standard-schema/spec@1.1.0': {}
-
-  '@types/chai@5.2.2':
-    dependencies:
-      '@types/deep-eql': 4.0.2
-
-  '@types/deep-eql@4.0.2': {}
-
-  '@types/estree@1.0.8': {}
-
   '@types/luxon@3.7.1': {}
 
   '@types/node@24.12.4':
@@ -1380,78 +595,13 @@ snapshots:
 
   '@vercel/ncc@0.38.4': {}
 
-  '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.6
-      ast-v8-to-istanbul: 1.0.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      magicast: 0.5.3
-      obug: 2.1.1
-      std-env: 4.1.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@7.1.5(@types/node@24.12.4))
-
-  '@vitest/expect@4.1.6':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      chai: 6.2.2
-      tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.6(vite@7.1.5(@types/node@24.12.4))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.1.5(@types/node@24.12.4)
-
-  '@vitest/pretty-format@4.1.6':
-    dependencies:
-      tinyrainbow: 3.1.0
-
-  '@vitest/runner@4.1.6':
-    dependencies:
-      '@vitest/utils': 4.1.6
-      pathe: 2.0.3
-
-  '@vitest/snapshot@4.1.6':
-    dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
-  '@vitest/spy@4.1.6': {}
-
-  '@vitest/utils@4.1.6':
-    dependencies:
-      '@vitest/pretty-format': 4.1.6
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  ast-v8-to-istanbul@1.0.0:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      estree-walker: 3.0.3
-      js-tokens: 10.0.0
-
   before-after-hook@4.0.0: {}
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
 
-  chai@6.2.2: {}
-
   content-type@2.0.0: {}
-
-  convert-source-map@2.0.0: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -1473,65 +623,13 @@ snapshots:
 
   entities@8.0.0: {}
 
-  es-module-lexer@2.1.0: {}
-
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-
-  estree-walker@3.0.3:
-    dependencies:
-      '@types/estree': 1.0.8
-
-  expect-type@1.3.0: {}
-
   fast-content-type-parse@3.0.0: {}
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
-
-  fsevents@2.3.3:
-    optional: true
-
-  has-flag@4.0.0: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  html-escaper@2.0.2: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -1542,21 +640,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
-
-  istanbul-lib-coverage@3.2.2: {}
-
-  istanbul-lib-report@3.0.1:
-    dependencies:
-      istanbul-lib-coverage: 3.2.2
-      make-dir: 4.0.0
-      supports-color: 7.2.0
-
-  istanbul-reports@3.2.0:
-    dependencies:
-      html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.1
-
-  js-tokens@10.0.0: {}
 
   jsbi@4.3.2: {}
 
@@ -1592,83 +675,20 @@ snapshots:
 
   luxon@3.7.2: {}
 
-  magic-string@0.30.21:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  magicast@0.5.3:
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-      source-map-js: 1.2.1
-
-  make-dir@4.0.0:
-    dependencies:
-      semver: 7.6.3
-
   mdn-data@2.27.1: {}
-
-  nanoid@3.3.12: {}
 
   node-ical@0.26.1:
     dependencies:
       rrule-temporal: 1.5.3
       temporal-polyfill: 0.3.2
 
-  obug@2.1.1: {}
-
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
 
-  pathe@2.0.3: {}
-
-  picocolors@1.1.1: {}
-
-  picomatch@4.0.3: {}
-
-  picomatch@4.0.4: {}
-
-  postcss@8.5.14:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   punycode@2.3.1: {}
 
   require-from-string@2.0.2: {}
-
-  rollup@4.60.3:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.3
-      '@rollup/rollup-android-arm64': 4.60.3
-      '@rollup/rollup-darwin-arm64': 4.60.3
-      '@rollup/rollup-darwin-x64': 4.60.3
-      '@rollup/rollup-freebsd-arm64': 4.60.3
-      '@rollup/rollup-freebsd-x64': 4.60.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
-      '@rollup/rollup-linux-arm64-gnu': 4.60.3
-      '@rollup/rollup-linux-arm64-musl': 4.60.3
-      '@rollup/rollup-linux-loong64-gnu': 4.60.3
-      '@rollup/rollup-linux-loong64-musl': 4.60.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
-      '@rollup/rollup-linux-ppc64-musl': 4.60.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
-      '@rollup/rollup-linux-riscv64-musl': 4.60.3
-      '@rollup/rollup-linux-s390x-gnu': 4.60.3
-      '@rollup/rollup-linux-x64-gnu': 4.60.3
-      '@rollup/rollup-linux-x64-musl': 4.60.3
-      '@rollup/rollup-openbsd-x64': 4.60.3
-      '@rollup/rollup-openharmony-arm64': 4.60.3
-      '@rollup/rollup-win32-arm64-msvc': 4.60.3
-      '@rollup/rollup-win32-ia32-msvc': 4.60.3
-      '@rollup/rollup-win32-x64-gnu': 4.60.3
-      '@rollup/rollup-win32-x64-msvc': 4.60.3
-      fsevents: 2.3.3
 
   rrule-temporal@1.5.3:
     dependencies:
@@ -1682,19 +702,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  semver@7.6.3: {}
-
-  siginfo@2.0.0: {}
-
   source-map-js@1.2.1: {}
-
-  stackback@0.0.2: {}
-
-  std-env@4.1.0: {}
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -1703,22 +711,6 @@ snapshots:
       temporal-spec: 0.3.1
 
   temporal-spec@0.3.1: {}
-
-  tinybench@2.9.0: {}
-
-  tinyexec@1.1.2: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.30: {}
 
@@ -1748,47 +740,6 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
-  vite@7.1.5(@types/node@24.12.4):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rollup: 4.60.3
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 24.12.4
-      fsevents: 2.3.3
-
-  vitest@4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@7.1.5(@types/node@24.12.4)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.1.5(@types/node@24.12.4))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.1.5(@types/node@24.12.4)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.12.4
-      '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -1804,11 +755,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  why-is-node-running@2.3.0:
-    dependencies:
-      siginfo: 2.0.0
-      stackback: 0.0.2
 
   xml-name-validator@5.0.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import DOMPurify from 'isomorphic-dompurify'
 
-import createIssueBody from './lib/createIssueBody'
-import extractInput from './lib/extractInput'
-import generateMeetingTimes from './lib/generateMeetingTimes'
-import getLabeledIssuesAndPRs from './lib/getLabeledIssuesAndPRs'
-import output from './lib/output'
-import parseICS from './lib/parseICS'
+import createIssueBody from './lib/createIssueBody.ts'
+import extractInput from './lib/extractInput.ts'
+import generateMeetingTimes from './lib/generateMeetingTimes.ts'
+import getLabeledIssuesAndPRs from './lib/getLabeledIssuesAndPRs.ts'
+import output from './lib/output.ts'
+import parseICS from './lib/parseICS.ts'
 
 const {
 	dryRun,

--- a/src/lib/__tests__/createIssueBody.test.ts
+++ b/src/lib/__tests__/createIssueBody.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
-import createIssueBody from '../createIssueBody'
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import createIssueBody from '../createIssueBody.ts'
 
 const MOCK_REPO = 'test-repo'
 const MOCK_SLACK = 'https://slack.com/test'
@@ -18,7 +19,9 @@ describe('createIssueBody', () => {
 			'agenda',
 		)
 
-		expect(result).toBe(`Agenda for test-repo meeting
+		assert.strictEqual(
+			result,
+			`Agenda for test-repo meeting
 
 ## Meeting Details
 
@@ -35,7 +38,8 @@ Tomorrow
 - Issue 1
 - Issue 2
 
-`)
+`,
+		)
 	})
 
 	it('should generate issue body without slack link', () => {
@@ -48,7 +52,9 @@ Tomorrow
 			'agenda',
 		)
 
-		expect(result).toBe(`Agenda for test-repo meeting
+		assert.strictEqual(
+			result,
+			`Agenda for test-repo meeting
 
 ## Meeting Details
 
@@ -65,7 +71,8 @@ Tomorrow
 - Issue 1
 - Issue 2
 
-`)
+`,
+		)
 	})
 
 	it('should generate issue body with empty issues', () => {
@@ -78,7 +85,9 @@ Tomorrow
 			'agenda',
 		)
 
-		expect(result).toBe(`Agenda for test-repo meeting
+		assert.strictEqual(
+			result,
+			`Agenda for test-repo meeting
 
 ## Meeting Details
 
@@ -94,6 +103,7 @@ Tomorrow
 
 
 
-`)
+`,
+		)
 	})
 })

--- a/src/lib/__tests__/extractInput.test.ts
+++ b/src/lib/__tests__/extractInput.test.ts
@@ -1,18 +1,23 @@
-import { getInput } from '@actions/core'
-import type { Mock } from 'vitest'
-import { describe, expect, it, vi } from 'vitest'
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
 
-import extractInput from '../extractInput'
+const getInput = mock.fn<(name: string) => string | undefined>()
 
-vi.mock('@actions/core')
-vi.mock('@actions/github', () => ({
-	context: {
-		repo: {
-			owner: 'test-owner', // hoisted, so cannot use MOCK_OWNER
-			repo: 'test-repo', // hoisted, so cannot use MOCK_REPO
+mock.module('@actions/core', {
+	namedExports: { getInput },
+})
+mock.module('@actions/github', {
+	namedExports: {
+		context: {
+			repo: {
+				owner: 'test-owner',
+				repo: 'test-repo',
+			},
 		},
 	},
-}))
+})
+
+const { default: extractInput } = await import('../extractInput.ts')
 
 const MOCK_GITHUB_TOKEN = 'test-token'
 const MOCK_OWNER = 'test-owner'
@@ -24,7 +29,7 @@ const MOCK_TIMEZONES = 'UTC,CST'
 describe('extractInput', () => {
 	describe('extractInput', () => {
 		it('should extract input correctly', () => {
-			;(getInput as Mock).mockImplementation((name: string) => {
+			getInput.mock.mockImplementation((name: string) => {
 				const inputs: { [key: string]: string } = {
 					GITHUB_TOKEN: MOCK_GITHUB_TOKEN,
 					MEETING_PATH: MOCK_PATH,
@@ -37,7 +42,7 @@ describe('extractInput', () => {
 
 			const input = extractInput()
 
-			expect(input).toEqual({
+			assert.deepStrictEqual(input, {
 				token: MOCK_GITHUB_TOKEN,
 				org: MOCK_OWNER,
 				repo: MOCK_REPO,
@@ -51,7 +56,7 @@ describe('extractInput', () => {
 		})
 
 		it('should handle optional inputs correctly', () => {
-			;(getInput as Mock).mockImplementation((name: string) => {
+			getInput.mock.mockImplementation((name: string) => {
 				const inputs: { [key: string]: string } = {
 					GITHUB_TOKEN: MOCK_GITHUB_TOKEN,
 					MEETING_PATH: MOCK_PATH,
@@ -62,7 +67,7 @@ describe('extractInput', () => {
 
 			const input = extractInput()
 
-			expect(input).toEqual({
+			assert.deepStrictEqual(input, {
 				token: MOCK_GITHUB_TOKEN,
 				org: MOCK_OWNER,
 				repo: MOCK_REPO,
@@ -76,7 +81,7 @@ describe('extractInput', () => {
 		})
 
 		it('should handle custom agenda label and org wide search', () => {
-			;(getInput as Mock).mockImplementation((name: string) => {
+			getInput.mock.mockImplementation((name: string) => {
 				const inputs: { [key: string]: string } = {
 					GITHUB_TOKEN: MOCK_GITHUB_TOKEN,
 					MEETING_PATH: MOCK_PATH,
@@ -89,7 +94,7 @@ describe('extractInput', () => {
 
 			const input = extractInput()
 
-			expect(input).toEqual({
+			assert.deepStrictEqual(input, {
 				token: MOCK_GITHUB_TOKEN,
 				org: MOCK_OWNER,
 				repo: MOCK_REPO,

--- a/src/lib/__tests__/generateMeetingTimes.test.ts
+++ b/src/lib/__tests__/generateMeetingTimes.test.ts
@@ -1,6 +1,7 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
 import { DateTime } from 'luxon'
-import { describe, expect, test } from 'vitest'
-import generateMeetingTimes from '../generateMeetingTimes'
+import generateMeetingTimes from '../generateMeetingTimes.ts'
 
 const MOCK_TIMEZONES = ['UTC', 'America/Chicago', 'Asia/Kolkata']
 const MOCK_DATE = DateTime.fromISO('2025-01-15T14:30:00Z')
@@ -8,8 +9,8 @@ const MOCK_DATE = DateTime.fromISO('2025-01-15T14:30:00Z')
 describe('generateMeetingTimes', () => {
 	test('should generate meeting times for multiple timezones', () => {
 		const result = generateMeetingTimes(MOCK_TIMEZONES, MOCK_DATE)
-		expect(result).toContain('2:30\u202fPM UTC') //dont ask why UTC formatting adds a unicode space
-		expect(result).toContain('8:30 AM America/Chicago')
-		expect(result).toContain('8:00 PM Asia/Kolkata')
+		assert.ok(result.includes('2:30\u202fPM UTC')) //dont ask why UTC formatting adds a unicode space
+		assert.ok(result.includes('8:30 AM America/Chicago'))
+		assert.ok(result.includes('8:00 PM Asia/Kolkata'))
 	})
 })

--- a/src/lib/__tests__/getLabeledIssuesAndPRs.test.ts
+++ b/src/lib/__tests__/getLabeledIssuesAndPRs.test.ts
@@ -1,15 +1,19 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, mock, test } from 'node:test'
 
-import getLabeledIssuesAndPRs from '../getLabeledIssuesAndPRs'
-import { paginateIssues } from '../paginateIssues'
+const paginateIssues = mock.fn<(...args: any[]) => Promise<any>>()
 
-vi.mock('../paginateIssues', () => ({
-	paginateIssues: vi.fn(),
-}))
+mock.module('../paginateIssues.ts', {
+	namedExports: { paginateIssues },
+})
+
+const { default: getLabeledIssuesAndPRs } = await import(
+	'../getLabeledIssuesAndPRs.ts'
+)
 
 describe('getLabeledIssuesAndPRs', () => {
 	afterEach(() => {
-		vi.clearAllMocks()
+		paginateIssues.mock.resetCalls()
 	})
 
 	let mockIssuesAndPRs: any[]
@@ -54,36 +58,37 @@ describe('getLabeledIssuesAndPRs', () => {
 	})
 
 	test('should return a list of issues and PRs with the agenda label', async () => {
-		;(paginateIssues as any).mockResolvedValue(mockIssuesAndPRs)
+		paginateIssues.mock.mockImplementation(async () => mockIssuesAndPRs)
 
 		const result = await getLabeledIssuesAndPRs('org', 'repo')
-		expect(result).toBe(
+		assert.strictEqual(
+			result,
 			'- [ ] https://github.com/org/repo/issues/1\n- [ ] https://github.com/org/repo/pull/4',
 		)
 	})
 
 	test('should return an empty string if no issues or PRs have the agenda label', async () => {
-		;(paginateIssues as any).mockResolvedValue([])
+		paginateIssues.mock.mockImplementation(async () => [])
 
 		const result = await getLabeledIssuesAndPRs('org', 'repo')
-		expect(result).toBe('')
+		assert.strictEqual(result, '')
 	})
 
 	test('should handle errors gracefully', async () => {
-		;(paginateIssues as any).mockRejectedValue(new Error('Network error'))
+		paginateIssues.mock.mockImplementation(async () => {
+			throw new Error('Network error')
+		})
 
-		const consoleErrorSpy = vi
-			.spyOn(console, 'error')
-			.mockImplementation(() => {})
+		const consoleErrorSpy = mock.method(console, 'error', () => {})
 
 		const result = await getLabeledIssuesAndPRs('org', 'repo')
-		expect(result).toBe('')
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
+		assert.strictEqual(result, '')
+		assert.deepStrictEqual(consoleErrorSpy.mock.calls[0].arguments, [
 			'Error fetching issues',
 			'Network error',
-		)
+		])
 
-		consoleErrorSpy.mockRestore()
+		consoleErrorSpy.mock.restore()
 	})
 
 	test('should use custom agenda label', async () => {
@@ -96,21 +101,21 @@ describe('getLabeledIssuesAndPRs', () => {
 				pull_request: null,
 			},
 		]
-		;(paginateIssues as any).mockResolvedValue(customLabeledIssues)
+		paginateIssues.mock.mockImplementation(async () => customLabeledIssues)
 
 		const result = await getLabeledIssuesAndPRs('org', 'repo', 'meeting-topic')
 
-		expect(result).toBe('- [ ] https://github.com/org/repo/issues/1')
-		expect(paginateIssues).toHaveBeenCalledWith(
+		assert.strictEqual(result, '- [ ] https://github.com/org/repo/issues/1')
+		assert.deepStrictEqual(paginateIssues.mock.calls[0].arguments, [
 			'org',
 			'repo',
 			false,
 			'meeting-topic',
-		)
+		])
 	})
 
 	test('should handle org-wide search', async () => {
-		;(paginateIssues as any).mockResolvedValue(mockOrgWideIssuesAndPRs)
+		paginateIssues.mock.mockImplementation(async () => mockOrgWideIssuesAndPRs)
 
 		const result = await getLabeledIssuesAndPRs(
 			'org',
@@ -119,14 +124,15 @@ describe('getLabeledIssuesAndPRs', () => {
 			true,
 		)
 
-		expect(result).toBe(
+		assert.strictEqual(
+			result,
 			'- [ ] https://github.com/org/repo1/issues/1\n- [ ] https://github.com/org/repo2/pull/4',
 		)
-		expect(paginateIssues).toHaveBeenCalledWith(
+		assert.deepStrictEqual(paginateIssues.mock.calls[0].arguments, [
 			'org',
 			'repo',
 			true,
 			'meeting-topic',
-		)
+		])
 	})
 })

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -1,16 +1,18 @@
-import { setOutput } from '@actions/core'
+import assert from 'node:assert/strict'
+import { afterEach, describe, mock, test } from 'node:test'
 import { DateTime } from 'luxon'
-import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import octokit from '../getOctokit'
-import output from '../output'
+const issuesCreate = mock.fn<(...args: any[]) => Promise<any>>()
+const setOutput = mock.fn()
 
-vi.mock('../getOctokit', () => ({
-	__esModule: true,
-	default: { rest: { issues: { create: vi.fn() } } },
-}))
+mock.module('../getOctokit.ts', {
+	defaultExport: { rest: { issues: { create: issuesCreate } } },
+})
+mock.module('@actions/core', {
+	namedExports: { setOutput },
+})
 
-vi.mock('@actions/core')
+const { default: output } = await import('../output.ts')
 
 const MOCK_OWNER = 'test-owner'
 const MOCK_REPO = 'test-repo'
@@ -18,19 +20,29 @@ const MOCK_CONTENT = 'test content'
 const MOCK_DATE = DateTime.fromISO('2025-01-15T14:30:00Z')
 const MOCK_LOCATION = 'test-location'
 
+// Mirrors vitest's `toHaveBeenCalledWith`: true if any recorded call matches.
+const calledWith = (m: typeof setOutput, ...args: unknown[]) =>
+	m.mock.calls.some((call) => {
+		try {
+			assert.deepStrictEqual(call.arguments, args)
+			return true
+		} catch {
+			return false
+		}
+	})
+
 describe('output', () => {
 	afterEach(() => {
-		vi.resetAllMocks()
+		issuesCreate.mock.resetCalls()
+		setOutput.mock.resetCalls()
+		mock.restoreAll()
 	})
 
 	test('creates an issue and sets outputs when not a dry run', async () => {
 		const newIssue = {
 			html_url: 'https://github.com/test-org/test-repo/issues/1',
 		}
-		vi.spyOn(octokit.rest.issues, 'create').mockResolvedValue({
-			//@ts-expect-error - we don't need the whole thing
-			data: newIssue,
-		})
+		issuesCreate.mock.mockImplementation(async () => ({ data: newIssue }))
 
 		await output(
 			MOCK_OWNER,
@@ -41,21 +53,20 @@ describe('output', () => {
 			MOCK_LOCATION,
 		)
 
-		expect(octokit.rest.issues.create).toHaveBeenCalled()
-		expect(setOutput).toHaveBeenCalledWith('ISSUE_URL', newIssue.html_url)
-		expect(setOutput).toHaveBeenCalledWith(
-			'NEXT_MEETING_DATE',
-			MOCK_DATE.toLocaleString(),
+		assert.ok(issuesCreate.mock.callCount() > 0)
+		assert.ok(calledWith(setOutput, 'ISSUE_URL', newIssue.html_url))
+		assert.ok(
+			calledWith(setOutput, 'NEXT_MEETING_DATE', MOCK_DATE.toLocaleString()),
 		)
-		expect(setOutput).toHaveBeenCalledWith('LOCATION', MOCK_LOCATION)
+		assert.ok(calledWith(setOutput, 'LOCATION', MOCK_LOCATION))
 	})
 
 	test('logs error when issue creation fails', async () => {
 		const error = new Error('Issue creation failed')
-		vi.spyOn(octokit.rest.issues, 'create').mockRejectedValue(error)
-		const consoleErrorSpy = vi
-			.spyOn(console, 'error')
-			.mockImplementation(() => {})
+		issuesCreate.mock.mockImplementation(async () => {
+			throw error
+		})
+		const consoleErrorSpy = mock.method(console, 'error', () => {})
 
 		await output(
 			MOCK_OWNER,
@@ -66,14 +77,14 @@ describe('output', () => {
 			MOCK_LOCATION,
 		)
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
+		assert.deepStrictEqual(consoleErrorSpy.mock.calls[0].arguments, [
 			'Error creating issue',
 			error.message,
-		)
+		])
 	})
 
 	test('only logs body content when dry run', async () => {
-		const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const consoleLogSpy = mock.method(console, 'log', () => {})
 
 		await output(
 			MOCK_OWNER,
@@ -84,10 +95,11 @@ describe('output', () => {
 			MOCK_LOCATION,
 		)
 
-		expect(consoleLogSpy).toHaveBeenCalledWith(
-			'Dry run, only outputting issue body',
-		)
-		expect(consoleLogSpy).toHaveBeenCalledWith(MOCK_CONTENT)
-		expect(octokit.rest.issues.create).not.toHaveBeenCalled()
+		const logArgs = consoleLogSpy.mock.calls.map((call) => call.arguments)
+		assert.deepStrictEqual(logArgs, [
+			['Dry run, only outputting issue body'],
+			[MOCK_CONTENT],
+		])
+		assert.strictEqual(issuesCreate.mock.callCount(), 0)
 	})
 })

--- a/src/lib/__tests__/parseICS.test.ts
+++ b/src/lib/__tests__/parseICS.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, mock, test } from 'node:test'
 
-import parseICS from '../parseICS'
+import parseICS from '../parseICS.ts'
 
 process.env.TZ = 'UTC'
+const ORIGINAL_TZ = process.env.TZ
 
 const MOCK_RECURRENCE = `
 BEGIN:VCALENDAR
@@ -85,45 +87,43 @@ const MOCK_DATE = new Date(2024, 11, 16) // December 16, 2024
 
 describe('parseICS', () => {
 	beforeEach(() => {
-		vi.setSystemTime(MOCK_DATE)
+		mock.timers.enable({ apis: ['Date'], now: MOCK_DATE })
 	})
 	afterEach(() => {
-		vi.unstubAllEnvs()
-		vi.useRealTimers()
+		process.env.TZ = ORIGINAL_TZ
+		mock.timers.reset()
 	})
 
 	test('should throw an error if rrule is not found', async () => {
-		expect(async () => await parseICS('')).rejects.toThrow(
-			'Could not find rrule within .ics file',
-		)
+		await assert.rejects(parseICS(''), /Could not find rrule within \.ics file/)
 	})
 
 	test('should find rrule if defined', async () => {
 		const { nextMeetingDateAndTimeUTC } = await parseICS(MOCK_RECURRENCE)
-		await expect(nextMeetingDateAndTimeUTC).toBeDefined()
+		assert.notStrictEqual(nextMeetingDateAndTimeUTC, undefined)
 	})
 
 	test('should find the next calculated recurrence', async () => {
 		const { nextMeetingDateAndTimeUTC } = await parseICS(MOCK_RECURRENCE)
-		expect(nextMeetingDateAndTimeUTC.toLocaleString()).toEqual('12/18/2024')
+		assert.strictEqual(nextMeetingDateAndTimeUTC.toLocaleString(), '12/18/2024')
 	})
 
 	test('during daylight savings time, should return correct UTC time', async () => {
-		vi.stubEnv('TZ', 'America/New_York')
-		vi.setSystemTime(new Date(2024, 5, 1)) // June 1, 2024
+		process.env.TZ = 'America/New_York'
+		mock.timers.setTime(new Date(2024, 5, 1).getTime()) // June 1, 2024
 		const { nextMeetingDateAndTimeUTC } = await parseICS(MOCK_RECURRENCE)
-		expect(nextMeetingDateAndTimeUTC.toISOTime()).toEqual('13:30:00.000Z')
+		assert.strictEqual(nextMeetingDateAndTimeUTC.toISOTime(), '13:30:00.000Z')
 	})
 
 	test('when it is not daylight savings time, should return correct UTC time', async () => {
-		vi.stubEnv('TZ', 'America/New_York')
-		vi.setSystemTime(new Date(2024, 11, 16)) // December 16, 2024
+		process.env.TZ = 'America/New_York'
+		mock.timers.setTime(new Date(2024, 11, 16).getTime()) // December 16, 2024
 		const { nextMeetingDateAndTimeUTC } = await parseICS(MOCK_RECURRENCE)
-		expect(nextMeetingDateAndTimeUTC.toISOTime()).toEqual('13:30:00.000Z')
+		assert.strictEqual(nextMeetingDateAndTimeUTC.toISOTime(), '13:30:00.000Z')
 	})
 
 	test('should find location if defined', async () => {
 		const { location } = await parseICS(MOCK_RECURRENCE)
-		expect(location).toBeDefined()
+		assert.notStrictEqual(location, undefined)
 	})
 })

--- a/src/lib/getLabeledIssuesAndPRs.ts
+++ b/src/lib/getLabeledIssuesAndPRs.ts
@@ -1,4 +1,4 @@
-import { paginateIssues } from './paginateIssues'
+import { paginateIssues } from './paginateIssues.ts'
 
 /**
  * Fetches all issues and pull requests from the repository or organization that have the specified label.

--- a/src/lib/getOctokit.ts
+++ b/src/lib/getOctokit.ts
@@ -1,6 +1,6 @@
 import { getOctokit } from '@actions/github'
 
-import extractInput from './extractInput'
+import extractInput from './extractInput.ts'
 
 const input = extractInput()
 const octokit = getOctokit(input.token)

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,7 +1,7 @@
 import { setOutput } from '@actions/core'
 import type { DateTime } from 'luxon'
 
-import octokit from './getOctokit'
+import octokit from './getOctokit.ts'
 
 const output = async (
 	org: string,

--- a/src/lib/paginateIssues.ts
+++ b/src/lib/paginateIssues.ts
@@ -1,4 +1,4 @@
-import octokit from './getOctokit'
+import octokit from './getOctokit.ts'
 /**
  * Fetches GitHub issues and/or PRs with a specific label
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"module": "esnext",
 		"rootDir": "./src",
 		"moduleResolution": "node",
+		"rewriteRelativeImportExtensions": true,
 		"baseUrl": "./",
 		"sourceMap": true,
 		"outDir": "./dist",
@@ -17,5 +18,5 @@
 		"newLine": "lf",
 		"resolveJsonModule": true
 	},
-	"exclude": ["./dist", "./node_modules", "./__tests__", "./coverage"]
+	"exclude": ["./dist", "./node_modules", "src/**/__tests__", "./coverage"]
 }


### PR DESCRIPTION
This pull request migrates the test suite from Vitest to Node.js's built-in test runner (`node:test`), and updates all related test files and mocking logic accordingly. It also removes Vitest and related dependencies from the project. Additionally, it updates import paths in the main source files to include the `.ts` extension for compatibility with Node.js ESM resolution.

**Test suite migration and modernization:**

* All test files in `src/lib/__tests__` have been rewritten to use `node:test` and Node.js's `assert` module instead of Vitest's `describe`, `it`, `expect`, and mocking utilities. Mocking is now handled via `node:test`'s `mock` API, and assertions use `assert` functions. 

* All mocking of modules (such as `@actions/core`, `@actions/github`, and internal modules) now uses `mock.module` and `mock.fn` from `node:test` instead of Vitest's `vi.mock`. 

**Package and dependency updates:**

* The `test` and `coverage` scripts in `package.json` have been updated to use `node --test` with the appropriate experimental flags, and a new `test:watch` script has been added.
* Vitest and its coverage plugin have been removed from `devDependencies` in `package.json`.

**Source code import compatibility:**

* All internal imports in `src/index.ts` have been updated to include the `.ts` extension, ensuring compatibility with Node.js ESM module resolution.

These changes collectively modernize the project's testing approach by leveraging Node.js's built-in capabilities and removing the dependency on Vitest.