### PR TITLE
Add CodeQL group to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,10 @@ updates:
       timezone: "Asia/Kolkata"
     allow:
       - dependency-type: "direct"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
This is now recommended since 4.37+ needs yolked updates, per github/codeql-action#4013.